### PR TITLE
feat(session-editor): pick SSH private key with a native file dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/xterm": "^6.0.0",
@@ -802,9 +803,9 @@
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1026,6 +1027,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.8.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/xterm": "^6.0.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2511,6 +2511,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2607,6 +2608,7 @@ dependencies = [
  "serialport",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-log",
  "time",
  "windows",
@@ -3324,6 +3326,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4169,6 +4195,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4475,6 +4543,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 time = { version = "0.3", features = ["formatting"] }
 log = "0.4"
 tauri = { version = "2.10.3", features = [] }
+tauri-plugin-dialog = "2"
 tauri-plugin-log = "2"
 font-kit = "0.14"
 libssh-rs = { version = "0.3", features = ["vendored", "vendored-openssl"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "core:default",
     "core:window:allow-close",
     "core:window:allow-start-dragging",
-    "core:webview:allow-create-webview-window"
+    "core:webview:allow-create-webview-window",
+    "dialog:allow-open"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod transfer;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .manage(runtime::AppRuntime::default())
         .setup(|app| {
             platform::menu::install_macos_menu(&app.handle())?;

--- a/src/components/forms/SessionEditorTabs.tsx
+++ b/src/components/forms/SessionEditorTabs.tsx
@@ -1,5 +1,6 @@
 import {
   ExternalLink,
+  FolderOpen,
   FolderTree,
   KeyRound,
   LockKeyhole,
@@ -7,7 +8,8 @@ import {
   ShieldOff,
 } from 'lucide-react'
 
-import { openExternalTarget } from '../../lib/bridge'
+import { logOpenXTermError } from '../../lib/errorLog'
+import { openExternalTarget, pickPrivateKeyFile } from '../../lib/bridge'
 import type { LocalX11Support, SessionDraft } from '../../types/domain'
 import { FontFamilyPicker } from './FontFamilyPicker'
 import {
@@ -282,11 +284,32 @@ export function SessionEditorConnectionTab({
             {draft.authType === 'key' && (
               <label className="editor-field editor-field-wide">
                 <span>Key path</span>
-                <input
-                  placeholder="~/.ssh/id_ed25519"
-                  value={draft.keyPath}
-                  onChange={(event) => updateDraft({ keyPath: event.target.value })}
-                />
+                <div className="key-path-row">
+                  <input
+                    placeholder="~/.ssh/id_ed25519"
+                    value={draft.keyPath}
+                    onChange={(event) => updateDraft({ keyPath: event.target.value })}
+                  />
+                  <button
+                    className="ghost-button key-path-browse"
+                    type="button"
+                    onClick={async () => {
+                      try {
+                        const picked = await pickPrivateKeyFile(draft.keyPath)
+                        if (picked) {
+                          updateDraft({ keyPath: picked })
+                        }
+                      } catch (error) {
+                        logOpenXTermError('session-editor.pick-key', error, {
+                          previousKeyPath: draft.keyPath,
+                        })
+                      }
+                    }}
+                  >
+                    <FolderOpen size={14} />
+                    <span>Choose…</span>
+                  </button>
+                </div>
               </label>
             )}
           </div>

--- a/src/lib/bridge.ts
+++ b/src/lib/bridge.ts
@@ -359,6 +359,29 @@ export async function openExternalTarget(target: string) {
   window.open(target, '_blank', 'noopener,noreferrer')
 }
 
+export async function pickPrivateKeyFile(defaultPath?: string): Promise<string | null> {
+  if (!isTauriRuntime()) {
+    return null
+  }
+
+  const { open } = await import('@tauri-apps/plugin-dialog')
+  const selection = await open({
+    multiple: false,
+    directory: false,
+    title: 'Select SSH private key',
+    defaultPath: defaultPath?.trim() || undefined,
+    filters: [
+      { name: 'SSH keys', extensions: ['pem', 'ppk', 'key'] },
+      { name: 'All files', extensions: ['*'] },
+    ],
+  })
+
+  if (typeof selection === 'string' && selection.trim().length > 0) {
+    return selection
+  }
+  return null
+}
+
 export async function listSystemFontFamilies() {
   if (isTauriRuntime()) {
     return invoke<string[]>('list_system_font_families')

--- a/src/styles/session-editor.css
+++ b/src/styles/session-editor.css
@@ -340,6 +340,27 @@
   max-width: 180px;
 }
 
+.key-path-row {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  min-width: 0;
+}
+
+.key-path-row > input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.key-path-browse {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  padding: 0 12px;
+}
+
 .session-auth-option,
 .terminal-preset-card {
   display: flex;


### PR DESCRIPTION
## Summary

When creating or editing an SSH session and switching auth to "Private key", users had to remember and hand-type the full path to their key file (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa_yadro`, `C:\Users\me\.ssh\id_rsa`, …). This PR adds a native **Choose…** button on the same row as the key-path input. Clicking it opens the system file picker.

## What changes

### Frontend

- `src/components/forms/SessionEditorTabs.tsx`
  - The `Key path` field becomes `input` + `Choose…` button side-by-side in a new `.key-path-row` container.
  - The button uses the existing `ghost-button` style and a `FolderOpen` icon (consistent with the rest of the editor).
  - Click handler calls `pickPrivateKeyFile(draft.keyPath)` (the current path is passed as `defaultPath`, so the dialog opens directly at the user's `~/.ssh` if anything is already typed).
  - Cancel from the dialog leaves the existing value untouched. Errors are routed through the central `logOpenXTermError` and never crash the modal.
- `src/lib/bridge.ts`
  - New `pickPrivateKeyFile(defaultPath?)`. In Tauri it dynamically imports `@tauri-apps/plugin-dialog` and calls `open(...)` with filters:
    - `SSH keys`: `pem`, `ppk`, `key`
    - `All files`: `*`
  - In the browser fallback it returns `null` (no native picker; the user keeps the textbox).
- `src/styles/session-editor.css`
  - `.key-path-row` is a flex row that keeps the input flexible and the button at the same vertical level. The button never wraps.

### Backend / Tauri

- `src-tauri/Cargo.toml` + `Cargo.lock`: depend on `tauri-plugin-dialog = "2"`.
- `src-tauri/src/lib.rs`: register `tauri_plugin_dialog::init()` on the Tauri builder, alongside the existing log plugin.
- `src-tauri/capabilities/default.json`: allow `dialog:allow-open`. Scope is intentionally narrow — only the existing windows already enumerated in the capability are affected.

### Package manifests

- `package.json` + `package-lock.json`: depend on `@tauri-apps/plugin-dialog ^2.7.1`.

## Manual flow

1. Open the New session modal, set kind = SSH, Advanced → auth type = Private key.
2. The Key path row shows the text input and a Choose… button on the right.
3. Click Choose… — the native picker opens. On macOS/Linux it lands in `~/.ssh` if you already typed a path that starts there; on Windows it follows the user-home convention.
4. Pick a file → its full path drops into the input. Cancel → input unchanged.

## Validation

- `npm run check` clean (tsc + eslint + vitest 5/5 pass).
- Local `cargo check` skipped — the sandbox does not have `libgtk-3-dev` / `libwebkit2gtk-4.1-dev`. `cargo fetch` did update `Cargo.lock` with `tauri-plugin-dialog` and its transitive deps, so CI compiles against the same lock as locally resolved.

## Risk

LOW. Additive change: existing key-path workflow (typing the path) keeps working unchanged. The picker is purely an extra convenience. Browser fallback returns `null` so non-Tauri sessions are unaffected. Permission scope on the capability is the minimum needed (`dialog:allow-open`).

https://claude.ai/code/session_014T6JCgihydncoWvv4SzsGX

---
_Generated by [Claude Code](https://claude.ai/code/session_014T6JCgihydncoWvv4SzsGX)_