### PR TITLE
fix(deps): pin @tauri-apps/plugin-dialog to 2.6.x for tauri 2.10 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
-        "@tauri-apps/plugin-dialog": "^2.7.1",
+        "@tauri-apps/plugin-dialog": "~2.6.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/xterm": "^6.0.0",
@@ -803,9 +803,9 @@
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
-      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1030,12 +1030,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
-      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
+      "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.11.0"
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.8.0",
-    "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-dialog": "~2.6.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/xterm": "^6.0.0",


### PR DESCRIPTION
Tauri's CLI verifies that the Rust crate `tauri` and the npm package `@tauri-apps/api` share the same major.minor. CI on PR #33 failed with:

    tauri (v2.10.3) : @tauri-apps/api (v2.11.0)

Root cause: `@tauri-apps/plugin-dialog@2.7.1` declares `@tauri-apps/api: ^2.11.0` as a hard dependency, so installing it forced the api package up by one minor. The Rust side stays on 2.10.3.

`@tauri-apps/plugin-dialog@2.6.0` (last release before the 2.11 bump) still depends on `@tauri-apps/api: ^2.8.0`, which resolves to the same 2.10.1 we already had on main. Downgrade the plugin-dialog pin to `~2.6.0` so api is not lifted.

Locally:
- `@tauri-apps/api` resolved to 2.10.1 (matches Rust 2.10.3 ✓)
- `@tauri-apps/plugin-dialog` resolved to 2.6.0
- `npm run check` clean (tsc + eslint + 5 vitest tests pass)

https://claude.ai/code/session_014T6JCgihydncoWvv4SzsGX