### PR TITLE
feat(ssh): verify host keys with a MobaXterm-style trust prompt

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -262,6 +262,14 @@ pub fn resize_terminal_session(
 }
 
 #[tauri::command]
+pub fn resolve_ssh_host_key(request_id: String, decision: String) -> Result<(), String> {
+    let decision = crate::runtime::HostKeyDecision::from_wire(&decision)
+        .ok_or_else(|| format!("unknown host key decision: {decision}"))?;
+    crate::runtime::resolve_host_key(&request_id, decision);
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn list_remote_directory(
     session: SessionDefinition,
     path: Option<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .manage(runtime::AppRuntime::default())
         .setup(|app| {
+            runtime::init_host_key(&app.handle());
             platform::menu::install_macos_menu(&app.handle())?;
             if cfg!(debug_assertions) {
                 app.handle().plugin(
@@ -49,6 +50,7 @@ pub fn run() {
             commands::read_clipboard_text,
             commands::stop_terminal_session,
             commands::resize_terminal_session,
+            commands::resolve_ssh_host_key,
             commands::list_remote_directory,
             commands::create_remote_directory,
             commands::delete_remote_entry,

--- a/src-tauri/src/runtime.rs
+++ b/src-tauri/src/runtime.rs
@@ -32,6 +32,7 @@ pub(in crate::runtime) use ssh::guidance::{
     SshRuntimeGuidanceState,
 };
 pub(crate) use ssh::open_embedded_sftp;
+pub(crate) use ssh::{init_host_key, resolve_host_key, HostKeyDecision};
 pub(in crate::runtime) use ssh::{
     cleanup_ssh_runtime_metadata, clear_ssh_runtime_auth, lock_embedded_ssh_channel,
     run_remote_ssh_script_with_label,

--- a/src-tauri/src/runtime/ssh/host_key.rs
+++ b/src-tauri/src/runtime/ssh/host_key.rs
@@ -1,0 +1,396 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc::{self, RecvTimeoutError},
+        Arc, Mutex, OnceLock,
+    },
+    time::{Duration, Instant},
+};
+
+use libssh_rs::{KnownHosts, PublicKeyHashType, Session as LibsshSession};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+const HOST_KEY_PROMPT_EVENT: &str = "openxterm://ssh-host-key-prompt";
+const DECISION_TIMEOUT: Duration = Duration::from_secs(300);
+const DECISION_POLL: Duration = Duration::from_millis(150);
+const REQUEST_PREFIX: &str = "hk-";
+
+static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+static KNOWN_HOSTS_PATH: OnceLock<PathBuf> = OnceLock::new();
+static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+/// What the user chose when asked to trust a host key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HostKeyDecision {
+    /// Store the key in the known_hosts file (and replace a changed one).
+    Store,
+    /// Connect this time only, without persisting the key.
+    Once,
+    /// Abort the connection.
+    Reject,
+}
+
+impl HostKeyDecision {
+    pub(crate) fn from_wire(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "store" | "overwrite" | "accept" => Some(Self::Store),
+            "once" => Some(Self::Once),
+            "reject" | "cancel" => Some(Self::Reject),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HostKeyKind {
+    Unknown,
+    Changed,
+}
+
+impl HostKeyKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            HostKeyKind::Unknown => "unknown",
+            HostKeyKind::Changed => "changed",
+        }
+    }
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct HostKeyPromptPayload {
+    request_id: String,
+    host: String,
+    port: u16,
+    fingerprint: String,
+    kind: &'static str,
+    session_label: String,
+}
+
+fn pending() -> &'static Mutex<HashMap<u64, mpsc::Sender<HostKeyDecision>>> {
+    static PENDING: OnceLock<Mutex<HashMap<u64, mpsc::Sender<HostKeyDecision>>>> = OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn accepted_once() -> &'static Mutex<HashSet<String>> {
+    static ACCEPTED_ONCE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    ACCEPTED_ONCE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn host_locks() -> &'static Mutex<HashMap<String, Arc<Mutex<()>>>> {
+    static HOST_LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+    HOST_LOCKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Wire up the app handle and resolve where known hosts are persisted.
+/// Called once during Tauri setup.
+pub(crate) fn init(app: &AppHandle) {
+    let _ = APP_HANDLE.set(app.clone());
+    if let Ok(dir) = app.path().app_data_dir() {
+        let _ = fs::create_dir_all(&dir);
+        let _ = KNOWN_HOSTS_PATH.set(dir.join("known_hosts"));
+    }
+}
+
+/// The known_hosts file path, if it could be resolved.
+pub(crate) fn known_hosts_path() -> Option<&'static Path> {
+    KNOWN_HOSTS_PATH.get().map(PathBuf::as_path)
+}
+
+/// Deliver a decision made in the UI back to the blocked connection thread.
+pub(crate) fn resolve(request_id: &str, decision: HostKeyDecision) {
+    let Some(sequence) = request_id
+        .strip_prefix(REQUEST_PREFIX)
+        .and_then(|value| value.parse::<u64>().ok())
+    else {
+        return;
+    };
+
+    let sender = pending()
+        .lock()
+        .ok()
+        .and_then(|mut map| map.remove(&sequence));
+    if let Some(sender) = sender {
+        let _ = sender.send(decision);
+    }
+}
+
+/// Verify the public key of the already-connected server against our
+/// known_hosts file. Unknown or changed keys raise a UI prompt and block
+/// until the user decides. Must be called after `connect()` but before
+/// any credentials are sent.
+pub(crate) fn verify_connected_server(
+    ssh: &LibsshSession,
+    host: &str,
+    port: u16,
+    session_label: &str,
+    abort: Option<&Arc<AtomicBool>>,
+) -> Result<(), String> {
+    if known_hosts_path().is_none() {
+        // Without a writable store we cannot pin or compare keys; skip rather
+        // than silently fall back to the user's ~/.ssh/known_hosts.
+        return Ok(());
+    }
+
+    if current_status(ssh)? == KnownHosts::Ok {
+        return Ok(());
+    }
+
+    let endpoint = format!("{host}:{port}");
+    let lock = host_lock(&endpoint);
+    let _guard = lock.lock().unwrap_or_else(|poison| poison.into_inner());
+
+    // Re-check under the per-host lock: a concurrent connection to the same
+    // host may have just stored the key while we waited for the lock.
+    let kind = match current_status(ssh)? {
+        KnownHosts::Ok => return Ok(()),
+        KnownHosts::NotFound | KnownHosts::Unknown => HostKeyKind::Unknown,
+        KnownHosts::Changed | KnownHosts::Other => HostKeyKind::Changed,
+    };
+
+    let fingerprint = server_fingerprint(ssh)?;
+    let once_key = format!("{endpoint}|{fingerprint}");
+    if accepted_once()
+        .lock()
+        .map(|set| set.contains(&once_key))
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    match prompt_decision(host, port, &fingerprint, kind, session_label, abort)? {
+        HostKeyDecision::Store => store_known_host(ssh, host, port, kind),
+        HostKeyDecision::Once => {
+            if let Ok(mut set) = accepted_once().lock() {
+                set.insert(once_key);
+            }
+            Ok(())
+        }
+        HostKeyDecision::Reject => Err(rejection_message(kind)),
+    }
+}
+
+fn current_status(ssh: &LibsshSession) -> Result<KnownHosts, String> {
+    ssh.is_known_server()
+        .map_err(|error| format!("failed to verify the server host key: {error}"))
+}
+
+fn server_fingerprint(ssh: &LibsshSession) -> Result<String, String> {
+    let key = ssh
+        .get_server_public_key()
+        .map_err(|error| format!("failed to read the server host key: {error}"))?;
+    key.get_public_key_hash_hexa(PublicKeyHashType::Sha256)
+        .map_err(|error| format!("failed to fingerprint the server host key: {error}"))
+}
+
+fn prompt_decision(
+    host: &str,
+    port: u16,
+    fingerprint: &str,
+    kind: HostKeyKind,
+    session_label: &str,
+    abort: Option<&Arc<AtomicBool>>,
+) -> Result<HostKeyDecision, String> {
+    let app = APP_HANDLE
+        .get()
+        .ok_or_else(|| "cannot prompt for host key trust: app handle is unavailable".to_string())?;
+
+    let sequence = REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let request_id = format!("{REQUEST_PREFIX}{sequence}");
+    let (sender, receiver) = mpsc::channel();
+    if let Ok(mut map) = pending().lock() {
+        map.insert(sequence, sender);
+    }
+
+    let _ = app.emit(
+        HOST_KEY_PROMPT_EVENT,
+        HostKeyPromptPayload {
+            request_id,
+            host: host.to_string(),
+            port,
+            fingerprint: fingerprint.to_string(),
+            kind: kind.as_str(),
+            session_label: session_label.to_string(),
+        },
+    );
+
+    let started = Instant::now();
+    let decision = loop {
+        if abort.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+            break HostKeyDecision::Reject;
+        }
+        match receiver.recv_timeout(DECISION_POLL) {
+            Ok(decision) => break decision,
+            Err(RecvTimeoutError::Timeout) => {
+                if started.elapsed() >= DECISION_TIMEOUT {
+                    break HostKeyDecision::Reject;
+                }
+            }
+            Err(RecvTimeoutError::Disconnected) => break HostKeyDecision::Reject,
+        }
+    };
+
+    if let Ok(mut map) = pending().lock() {
+        map.remove(&sequence);
+    }
+
+    Ok(decision)
+}
+
+fn store_known_host(
+    ssh: &LibsshSession,
+    host: &str,
+    port: u16,
+    kind: HostKeyKind,
+) -> Result<(), String> {
+    if kind == HostKeyKind::Changed {
+        if let Some(path) = known_hosts_path() {
+            remove_host_lines(path, host, port)?;
+        }
+    }
+
+    ssh.update_known_hosts_file()
+        .map_err(|error| format!("failed to store the server host key: {error}"))?;
+
+    if let Some(path) = known_hosts_path() {
+        harden_permissions(path);
+    }
+
+    Ok(())
+}
+
+/// The token libssh writes for a host: the bare hostname on port 22,
+/// otherwise the bracketed `[host]:port` form.
+fn host_token(host: &str, port: u16) -> String {
+    if port == 22 {
+        host.to_string()
+    } else {
+        format!("[{host}]:{port}")
+    }
+}
+
+/// Drop every existing known_hosts line that matches this host so an
+/// "overwrite" really replaces a changed key instead of leaving a stale one.
+fn remove_host_lines(path: &Path, host: &str, port: u16) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read known_hosts: {error}"))?;
+    let token = host_token(host, port);
+
+    let kept = content
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return true;
+            }
+            let patterns = trimmed.split_whitespace().next().unwrap_or_default();
+            !patterns
+                .split(',')
+                .any(|pattern| pattern == token || pattern == host)
+        })
+        .collect::<Vec<_>>();
+
+    let mut rewritten = kept.join("\n");
+    if !rewritten.is_empty() {
+        rewritten.push('\n');
+    }
+    fs::write(path, rewritten)
+        .map_err(|error| format!("failed to rewrite known_hosts: {error}"))
+}
+
+fn harden_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+fn host_lock(endpoint: &str) -> Arc<Mutex<()>> {
+    let mut map = host_locks()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    map.entry(endpoint.to_string())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+fn rejection_message(kind: HostKeyKind) -> String {
+    match kind {
+        HostKeyKind::Unknown => {
+            "Connection cancelled: the server host key was not trusted.".to_string()
+        }
+        HostKeyKind::Changed => {
+            "Connection cancelled: the server host key has changed and was not trusted.".to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_token_uses_bracket_form_for_non_default_ports() {
+        assert_eq!(host_token("example.com", 22), "example.com");
+        assert_eq!(host_token("example.com", 2222), "[example.com]:2222");
+    }
+
+    #[test]
+    fn decision_parses_known_wire_values() {
+        assert_eq!(HostKeyDecision::from_wire("store"), Some(HostKeyDecision::Store));
+        assert_eq!(
+            HostKeyDecision::from_wire("overwrite"),
+            Some(HostKeyDecision::Store)
+        );
+        assert_eq!(HostKeyDecision::from_wire("ONCE"), Some(HostKeyDecision::Once));
+        assert_eq!(
+            HostKeyDecision::from_wire("cancel"),
+            Some(HostKeyDecision::Reject)
+        );
+        assert_eq!(HostKeyDecision::from_wire("nonsense"), None);
+    }
+
+    #[test]
+    fn remove_host_lines_drops_matching_host_and_keeps_others() {
+        let dir = std::env::temp_dir().join(format!(
+            "openxterm-known-hosts-test-{}",
+            REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("known_hosts");
+        fs::write(
+            &path,
+            "example.com ssh-ed25519 AAAAOLD\n\
+             [example.com]:2222 ssh-ed25519 AAAAPORTED\n\
+             other.test ssh-ed25519 AAAAKEEP\n\
+             # comment line\n",
+        )
+        .expect("seed known_hosts");
+
+        remove_host_lines(&path, "example.com", 22).expect("rewrite known_hosts");
+
+        let result = fs::read_to_string(&path).expect("read known_hosts");
+        assert!(!result.contains("AAAAOLD"), "stale port-22 line should be gone");
+        assert!(
+            result.contains("AAAAPORTED"),
+            "the [host]:2222 entry should survive a port-22 removal"
+        );
+        assert!(result.contains("AAAAKEEP"), "unrelated host should survive");
+        assert!(result.contains("# comment line"), "comments should survive");
+
+        fs::remove_dir_all(&dir).expect("cleanup temp dir");
+    }
+}

--- a/src-tauri/src/runtime/ssh/interactive.rs
+++ b/src-tauri/src/runtime/ssh/interactive.rs
@@ -233,6 +233,7 @@ impl EmbeddedSshController {
                 .lock()
                 .unwrap_or_else(|poison| poison.into_inner()),
             x11_config.as_ref(),
+            Some(&self.stop_flag),
         ) {
             Ok((channel, x11_warning)) => {
                 let shared_channel = Arc::new(Mutex::new(channel));

--- a/src-tauri/src/runtime/ssh/mod.rs
+++ b/src-tauri/src/runtime/ssh/mod.rs
@@ -1,5 +1,6 @@
 mod auth;
 pub(super) mod guidance;
+mod host_key;
 mod interactive;
 mod interactive_reader;
 mod interactive_text;
@@ -7,6 +8,7 @@ mod ppk;
 mod session;
 
 pub(in crate::runtime) use auth::{cleanup_ssh_runtime_metadata, clear_ssh_runtime_auth};
+pub(crate) use host_key::{init as init_host_key, resolve as resolve_host_key, HostKeyDecision};
 pub(in crate::runtime) use interactive::lock_embedded_ssh_channel;
 pub(crate) use session::open_embedded_sftp;
 pub(in crate::runtime) use session::run_remote_ssh_script_with_label;

--- a/src-tauri/src/runtime/ssh/session.rs
+++ b/src-tauri/src/runtime/ssh/session.rs
@@ -1,3 +1,4 @@
+use std::sync::{atomic::AtomicBool, Arc};
 use std::{fs, io::Read};
 
 use std::time::Duration;
@@ -31,6 +32,7 @@ use super::super::{expand_tilde, shell_quote};
 use super::{
     auth::{ssh_runtime_password, ssh_runtime_username, ssh_runtime_username_path_for_tab},
     guidance::{humanize_ssh_error_message, windows_credential_reuse_message},
+    host_key,
     ppk::load_private_key_for_libssh,
 };
 
@@ -91,12 +93,14 @@ pub(in crate::runtime) fn open_embedded_ssh_channel(
     password_override: Option<&str>,
     terminal_size: (u16, u16),
     x11_config: Option<&X11ForwardConfig>,
+    abort: Option<&Arc<AtomicBool>>,
 ) -> Result<(LibsshChannel, Option<String>), String> {
     let ssh = connect_embedded_ssh_session_with_username(
         session,
         username,
         password_override,
         "interactive session",
+        abort,
     )?;
 
     match open_interactive_session_channel(
@@ -491,6 +495,7 @@ fn connect_embedded_ssh_session_with_username(
     username: &str,
     password_override: Option<&str>,
     context: &str,
+    abort: Option<&Arc<AtomicBool>>,
 ) -> Result<LibsshSession, String> {
     let ssh = LibsshSession::new()
         .map_err(|error| format!("failed to create embedded SSH {context}: {error}"))?;
@@ -506,7 +511,8 @@ fn connect_embedded_ssh_session_with_username(
         .map_err(|error| format!("failed to configure embedded SSH username: {error}"))?;
     ssh.set_option(SshOption::Timeout(EMBEDDED_SSH_TIMEOUT))
         .map_err(|error| format!("failed to configure embedded SSH timeout: {error}"))?;
-    ssh.set_option(SshOption::KnownHosts(None))
+    let known_hosts_option = host_key::known_hosts_path().map(|path| path.to_string_lossy().to_string());
+    ssh.set_option(SshOption::KnownHosts(known_hosts_option))
         .map_err(|error| format!("failed to configure embedded SSH known_hosts path: {error}"))?;
     ssh.set_option(SshOption::GlobalKnownHosts(None))
         .map_err(|error| {
@@ -538,6 +544,14 @@ fn connect_embedded_ssh_session_with_username(
             session,
         )
     })?;
+
+    // Verify the server host key before any credentials leave the client.
+    let session_label = if session.name.trim().is_empty() {
+        host
+    } else {
+        session.name.trim()
+    };
+    host_key::verify_connected_server(&ssh, host, session.port, session_label, abort)?;
 
     match session.auth_type.as_str() {
         "password" => {
@@ -674,7 +688,7 @@ pub(crate) fn connect_embedded_ssh_session(
 ) -> Result<LibsshSession, String> {
     let username = ssh_helper_username(session, runtime_tab_id)?;
     let secret = ssh_helper_secret(session, runtime_tab_id);
-    connect_embedded_ssh_session_with_username(session, &username, secret.as_deref(), context)
+    connect_embedded_ssh_session_with_username(session, &username, secret.as_deref(), context, None)
 }
 
 pub(crate) fn open_embedded_sftp(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,16 +7,31 @@ import { DeleteSessionFolderModal } from './components/forms/DeleteSessionFolder
 import { SessionEditorModal } from './components/forms/SessionEditorModal'
 import { AppSettingsModal, type AppSettingsTab } from './components/forms/AppSettingsModal'
 import { AppLockOverlay } from './components/forms/AppLockOverlay'
+import { HostKeyPromptModal } from './components/forms/HostKeyPromptModal'
 import { TopBar } from './components/layout/TopBar'
 import { installEditablePasteShortcut } from './lib/editablePaste'
-import { getSystemAuthSupport, listenMenuAction, requestSystemUnlock } from './lib/bridge'
+import {
+  getSystemAuthSupport,
+  listenMenuAction,
+  listenSshHostKeyPrompt,
+  requestSystemUnlock,
+  resolveSshHostKey,
+} from './lib/bridge'
 import { normalizeSessionFolderPath } from './lib/sessionUtils'
 import { StatusBar } from './components/status/StatusBar'
 import { Sidebar } from './components/sidebar/Sidebar'
 import { Workspace } from './components/workspace/Workspace'
 import { isFolderPathInSubtree } from './state/openXTermStoreHelpers'
 import { useOpenXTermStore } from './state/useOpenXTermStore'
-import type { MacroDefinition, MenuAction, SessionDefinition, SessionFolderDefinition, SystemAuthSupport } from './types/domain'
+import type {
+  HostKeyDecision,
+  HostKeyPromptPayload,
+  MacroDefinition,
+  MenuAction,
+  SessionDefinition,
+  SessionFolderDefinition,
+  SystemAuthSupport,
+} from './types/domain'
 
 export function App() {
   const isMacOS = navigator.userAgent.includes('Mac')
@@ -74,6 +89,7 @@ export function App() {
   const [settingsInitialTab, setSettingsInitialTab] = useState<AppSettingsTab>('interface')
   const [moveSessionModalOpen, setMoveSessionModalOpen] = useState(false)
   const [sessionFolderModalOpen, setSessionFolderModalOpen] = useState(false)
+  const [hostKeyPrompts, setHostKeyPrompts] = useState<HostKeyPromptPayload[]>([])
   const [sidebarWidthDraft, setSidebarWidthDraft] = useState<number | null>(null)
   const [lockSupport, setLockSupport] = useState<SystemAuthSupport>({
     available: false,
@@ -101,6 +117,40 @@ export function App() {
   }, [initialize])
 
   useEffect(() => installEditablePasteShortcut(), [])
+
+  useEffect(() => {
+    let disposed = false
+    let unlisten = () => {}
+
+    void listenSshHostKeyPrompt((payload) => {
+      setHostKeyPrompts((current) =>
+        current.some((item) => item.requestId === payload.requestId)
+          ? current
+          : [...current, payload],
+      )
+    }).then((dispose) => {
+      if (disposed) {
+        void dispose()
+      } else {
+        unlisten = dispose
+      }
+    })
+
+    return () => {
+      disposed = true
+      unlisten()
+    }
+  }, [])
+
+  const handleHostKeyDecision = useCallback((decision: HostKeyDecision) => {
+    setHostKeyPrompts((current) => {
+      const [head, ...rest] = current
+      if (head) {
+        void resolveSshHostKey(head.requestId, decision)
+      }
+      return rest
+    })
+  }, [])
 
   useEffect(() => {
     if (!initialized) {
@@ -610,6 +660,14 @@ export function App() {
             setMacroModalOpen(false)
             setEditingMacro(null)
           }}
+        />
+      )}
+
+      {hostKeyPrompts[0] && (
+        <HostKeyPromptModal
+          key={hostKeyPrompts[0].requestId}
+          prompt={hostKeyPrompts[0]}
+          onDecision={handleHostKeyDecision}
         />
       )}
 

--- a/src/components/forms/HostKeyPromptModal.tsx
+++ b/src/components/forms/HostKeyPromptModal.tsx
@@ -1,0 +1,83 @@
+import { ShieldAlert, ShieldQuestion } from 'lucide-react'
+
+import type { HostKeyDecision, HostKeyPromptPayload } from '../../types/domain'
+
+interface HostKeyPromptModalProps {
+  prompt: HostKeyPromptPayload
+  onDecision: (decision: HostKeyDecision) => void
+}
+
+export function HostKeyPromptModal({ prompt, onDecision }: HostKeyPromptModalProps) {
+  const changed = prompt.kind === 'changed'
+  const endpoint = `${prompt.host}:${prompt.port}`
+  const showSessionLabel = Boolean(prompt.sessionLabel) && prompt.sessionLabel !== prompt.host
+
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <div
+        className="modal-panel host-key-modal"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="host-key-title"
+        aria-describedby="host-key-copy"
+      >
+        <div className="modal-header">
+          <h2 id="host-key-title" className={changed ? 'host-key-title danger' : 'host-key-title'}>
+            {changed ? <ShieldAlert size={18} /> : <ShieldQuestion size={18} />}
+            {changed ? 'Server host key has changed' : 'Unknown server host key'}
+          </h2>
+        </div>
+
+        <div className="host-key-body">
+          <p id="host-key-copy" className={changed ? 'host-key-warning' : undefined}>
+            {changed ? (
+              <>
+                The host key for <strong>{endpoint}</strong> does not match the key saved on an earlier
+                connection. The server may have been reinstalled — or someone could be intercepting the
+                connection (a man-in-the-middle attack). Continue only if you know why the key changed.
+              </>
+            ) : (
+              <>
+                The authenticity of <strong>{endpoint}</strong> can&apos;t be established yet. Check that the
+                fingerprint below matches the server before you trust it.
+              </>
+            )}
+          </p>
+
+          <dl className="host-key-fields">
+            {showSessionLabel && (
+              <div className="host-key-field">
+                <dt>Session</dt>
+                <dd>{prompt.sessionLabel}</dd>
+              </div>
+            )}
+            <div className="host-key-field">
+              <dt>Host</dt>
+              <dd>{endpoint}</dd>
+            </div>
+            <div className="host-key-field">
+              <dt>SHA256</dt>
+              <dd className="host-key-fingerprint">{prompt.fingerprint}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="modal-actions">
+          <button className="ghost-button" type="button" onClick={() => onDecision('reject')}>
+            Cancel
+          </button>
+          <button className="ghost-button" type="button" onClick={() => onDecision('once')}>
+            Connect once
+          </button>
+          <button
+            className={changed ? 'solid-button danger' : 'solid-button'}
+            type="button"
+            onClick={() => onDecision('store')}
+          >
+            {changed ? 'Overwrite & save' : 'Accept & save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/bridge.ts
+++ b/src/lib/bridge.ts
@@ -9,6 +9,8 @@ import type {
   AppBootstrap,
   DownloadTargetInspection,
   FileDownloadResult,
+  HostKeyDecision,
+  HostKeyPromptPayload,
   LibsshProbePayload,
   LocalX11Support,
   MacroDefinition,
@@ -786,6 +788,24 @@ export async function listenTerminalExit(handler: (payload: TerminalExitPayload)
   return listen<TerminalExitPayload>('openxterm://terminal-exit', (event) => {
     handler(event.payload)
   })
+}
+
+export async function listenSshHostKeyPrompt(handler: (payload: HostKeyPromptPayload) => void) {
+  if (!isTauriRuntime()) {
+    return () => {}
+  }
+
+  return listen<HostKeyPromptPayload>('openxterm://ssh-host-key-prompt', (event) => {
+    handler(event.payload)
+  })
+}
+
+export async function resolveSshHostKey(requestId: string, decision: HostKeyDecision) {
+  if (!isTauriRuntime()) {
+    return
+  }
+
+  await invoke<void>('resolve_ssh_host_key', { requestId, decision })
 }
 
 export async function listenSessionStatus(handler: (payload: SessionStatusPayload) => void) {

--- a/src/styles/session-editor.css
+++ b/src/styles/session-editor.css
@@ -737,3 +737,82 @@
     border-bottom: 1px solid var(--color-border-subtle);
   }
 }
+
+.host-key-modal {
+  width: min(520px, calc(100vw - 32px));
+  padding: 18px 20px 16px;
+}
+
+.host-key-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.host-key-title.danger {
+  color: var(--color-danger-text);
+}
+
+.host-key-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 4px;
+}
+
+.host-key-body p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-muted);
+}
+
+.host-key-warning {
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-danger);
+  border-radius: 8px;
+  background: var(--color-surface-danger);
+  color: var(--color-danger-text) !important;
+}
+
+.host-key-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+}
+
+.host-key-field {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  align-items: baseline;
+  gap: 10px;
+}
+
+.host-key-field dt {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.host-key-field dd {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text);
+  word-break: break-all;
+}
+
+.host-key-fingerprint {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  padding: 6px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface-input);
+}
+
+.solid-button.danger {
+  border-color: var(--color-border-danger);
+  background: var(--color-surface-danger);
+  color: var(--color-danger-text);
+}

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -166,6 +166,19 @@ export interface TerminalExitPayload {
   reason: string
 }
 
+export type HostKeyPromptKind = 'unknown' | 'changed'
+
+export interface HostKeyPromptPayload {
+  requestId: string
+  host: string
+  port: number
+  fingerprint: string
+  kind: HostKeyPromptKind
+  sessionLabel: string
+}
+
+export type HostKeyDecision = 'store' | 'once' | 'reject'
+
 export interface SessionStatusPayload {
   tabId: string
   mode: 'live' | 'limited' | 'offline' | 'error'


### PR DESCRIPTION
## What & why

Closes #47 — the embedded SSH runtime disabled `known_hosts` entirely, so the client trusted **any** server key and would even hand the password to a man-in-the-middle. This adds real, MobaXterm-style host-key verification.

## Behaviour

Right after `connect()`, **before any credentials are sent**, we check the server key against our `known_hosts`:

- **Known & unchanged** → connect silently.
- **Unknown host** → dialog: **Accept & save** / **Connect once** / **Cancel**.
- **Changed key** → red warning dialog (possible MITM): **Overwrite & save** / **Connect once** / **Cancel**.

This applies to every embedded SSH/SFTP path — interactive terminals *and* the standalone SFTP file browser. "Connect once" is remembered in memory for the host so the file browser doesn't re-prompt on every directory listing; closing a terminal tab aborts a pending prompt.

## Implementation

- **`runtime/ssh/host_key.rs`** (new): `known_hosts` in `app_data_dir` (chmod `0600`), `is_known_server()` gate, event→block→`resolve_ssh_host_key` round-trip, clean overwrite of changed keys (strips stale lines), per-host serialization with re-check under lock, in-memory accept-once cache.
- **`session.rs`**: points libssh at our `known_hosts`, verifies before auth, threads an abort flag through the interactive path.
- **Frontend**: `HostKeyPromptModal` + a queue in `App.tsx`; shows host:port and the SHA256 fingerprint.

## Tests

- Rust unit tests: `known_hosts` host-line rewriting, decision parsing, host-token formatting.
- Full suite green: `cargo test --lib` (49 passed), `cargo clippy` clean, `npm run check` (tsc + eslint + style tokens + vitest).

## Manual check still worth doing

Connect to a brand-new host (see the accept dialog), then change the server key and reconnect (see the red changed-key warning, try overwrite vs once vs cancel).
